### PR TITLE
Fix/logout api integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,9 @@
   <link rel="stylesheet" href="styles/header.css">
   <link rel="stylesheet" href="styles/footer.css">
   <link rel="stylesheet" href="styles/home.css">
+
+  <script type="module" src="config/config.js"></script>
+  <script type="module" src="scripts/api.js"></script>
   <script type="module" src="scripts/components.js"></script>
   <script type="module" src="scripts/main.js" defer></script>
 </head>

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -30,7 +30,7 @@ export async function login(credentials) {
 }
 
 // 로그아웃 요청
-export async function logout() {
+window.logout = async function () {
     try {
         const refresh_token = localStorage.getItem("refresh_token");
         if (!refresh_token) throw new Error("리프레시 토큰이 없습니다.");
@@ -46,7 +46,7 @@ export async function logout() {
         console.error("로그아웃 실패:", error.response?.data || error.message);
         throw new Error(error.response?.data?.detail || "로그아웃 실패. 다시 시도하세요.");
     }
-}
+};
 
 // 현재 로그인 상태 확인
 export function isLoggedIn() {

--- a/scripts/components.js
+++ b/scripts/components.js
@@ -1,14 +1,14 @@
 document.addEventListener("DOMContentLoaded", function () {
     renderHeader();
     renderFooter();
-  });
-  
-  /**
-   * 헤더 동적 생성 (로그인 상태 확인하여 버튼 변경)
-   */
-  function renderHeader() {
+});
+
+/**
+ * 헤더 동적 생성 (로그인 상태 확인하여 버튼 변경)
+ */
+function renderHeader() {
     const isLoggedIn = localStorage.getItem("access_token") !== null;
-  
+
     const headerHTML = `
         <header class="header">
             <div class="header-container">
@@ -31,19 +31,14 @@ document.addEventListener("DOMContentLoaded", function () {
             </div>
         </header>
     `;
-  
+
     document.body.insertAdjacentHTML("afterbegin", headerHTML);
-  
-    // 로그아웃 버튼 이벤트 리스너 추가
-    if (isLoggedIn) {
-        document.querySelector(".logout-btn").addEventListener("click", handleLogout);
-    }
-  }
-  
-  /**
-   * 푸터 동적 생성
-   */
-  function renderFooter() {
+}
+
+/**
+ * 🚀 푸터 동적 생성
+ */
+function renderFooter() {
     const footerHTML = `
         <footer class="footer">
             <div class="footer-container">
@@ -78,16 +73,33 @@ document.addEventListener("DOMContentLoaded", function () {
             </div>
         </footer>
     `;
-  
+
     document.body.insertAdjacentHTML("beforeend", footerHTML);
-  }
-  
-  /**
-   * 로그아웃 처리
-   */
-  function handleLogout() {
-    localStorage.removeItem("access_token");  // 액세스 토큰 삭제
-    localStorage.removeItem("refresh_token"); // 리프레시 토큰 삭제
-    alert("로그아웃 되었습니다.");
-    window.location.href = "/"; // 메인 페이지로 이동
-  }
+}
+
+/**
+ * 로그아웃 버튼 이벤트 리스너 (이벤트 위임 방식)
+ */
+document.addEventListener("click", async function (event) {
+    if (event.target.classList.contains("logout-btn")) {
+        event.preventDefault(); // 기본 동작 방지 (페이지 새로고침 막기)
+        await handleLogout();
+    }
+});
+
+/**
+ * 로그아웃 처리 (`api.js`의 `logout()` 함수 호출)
+ */
+async function handleLogout() {
+    try {
+        if (typeof window.logout === "function") {
+            await window.logout(); // `api.js`의 logout() 호출
+            alert("로그아웃 되었습니다.");
+            window.location.href = "/"; // 메인 페이지로 이동
+        } else {
+            console.error("window.logout 함수가 정의되지 않았습니다.");
+        }
+    } catch (error) {
+        alert(error.message || "로그아웃 실패. 다시 시도하세요."); // 오류 메시지 출력
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- 없음

## 작업 내용
<!-- 작업한 내용을 자세히 설명해주세요 -->
- 기존 프론트엔드 로그아웃은 로컬 스토리지 토큰만 삭제하는 방식이었음
- 기존에 정의되어 있던 `api.js`의 `logout()` 함수는 호출하지 않아 백엔드와 연동되지 않았음
- 해당 함수(`logout()`)를 전역 함수로 등록하여 `components.js`에서도 호출 가능하도록 변경
- 이제 로그아웃 버튼 클릭 시 백엔드에 로그아웃 요청을 보내고, 토큰 블랙리스트 처리까지 연동됨
- 이벤트 위임 방식으로 `.logout-btn` 클릭을 감지하고 로그아웃 처리

## 테스트 체크리스트
<!-- [ ]안에 x를 입력하면 체크됩니다 -->
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->
(변경없음)

## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->
- `components.js`에서 `logout()`을 직접 import할 수 없어 전역 등록 방식(`window.logout`)으로 처리함
- `index.html`에서 반드시 `api.js`가 `components.js`보다 먼저 로드되어야 합니다