### PR TITLE
Markdown 랜더링 기능 추가

### DIFF
--- a/styles/chatbot.css
+++ b/styles/chatbot.css
@@ -89,6 +89,16 @@
     border-top-left-radius: 0;
 }
 
+ul {
+    list-style-type: disc;
+    padding-left: 20px;
+}
+
+ol {
+    list-style-type: decimal;
+    padding-left: 20px;
+}
+
 /* .user-message {
     align-self: flex-end;
     background: white;


### PR DESCRIPTION
## 작업 내용
<!-- 작업한 내용을 자세히 설명해주세요 -->
 1. 챗봇 응답에서 Markdown 랜더링 가능
- 챗봇의 응답에서 Markdown 형식 반영해서 출력됨
- `marked.js`를 활용해서 메시지를 HTML로 변환
- `currentMarkdownText` 변수를 이용해서 Markdown 파싱을 유지하고, `currentBotMessage`에 전달
- 추후에 XSS (Cross-Site Scripting) 보안 개선해야 함

2. Markdown 목록 스타일 개선
- `ul` 태그, `ol`태그들의 목록 들여쓰기를 하드코딩으로 개선

## 테스트 체크리스트
<!-- [ ]안에 x를 입력하면 체크됩니다 -->
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->
변경 전
<img width="942" alt="스크린샷 2025-03-10 오후 8 42 28" src="https://github.com/user-attachments/assets/2d3545a1-7c11-496d-bc44-0cb356c59d84" />
<img width="817" alt="스크린샷 2025-03-10 오후 6 32 43" src="https://github.com/user-attachments/assets/9062e537-ae2b-430f-9a8e-4a64193a6d9e" />
변경 후
<img width="907" alt="스크린샷 2025-03-10 오후 8 55 06" src="https://github.com/user-attachments/assets/73470055-b9d0-4edc-9547-8aa9a94ffd22" />


## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->