### PR TITLE
Feat/social login

### DIFF
--- a/pages/login.html
+++ b/pages/login.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="../styles/login.css">
   
     <!-- JavaScript 파일들 -->
+    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
     <script type="module" src="../config/config.js"></script>
     <script type="module" src="../scripts/api.js"></script>
     <script type="module" src="../scripts/components.js"></script>
@@ -60,7 +61,7 @@
           Google
         </button>
 
-        <button class="btn btn-kakao btn-block">
+        <button id="kakao-login-btn" class="btn btn-kakao btn-block">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18">
             <path fill="#3A1D1D" d="M12 3C7.03 3 3 6.14 3 10c0 2.44 1.56 4.61 3.94 5.8-.18.69-.71 2.51-.82 2.9-.12.47.18.46.38.33.16-.09 2.46-1.67 3.46-2.35.33.05.67.07 1.04.07 4.97 0 9-3.14 9-7S16.97 3 12 3z"/>
           </svg>

--- a/pages/signup.html
+++ b/pages/signup.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="../styles/signup.css">
   
     <!-- JavaScript 파일들 -->
+    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
     <script type="module" src="../config/config.js"></script>
     <script type="module" src="../scripts/api.js"></script>
     <script type="module" src="../scripts/components.js"></script>
@@ -21,7 +22,6 @@
     <script type="module" src="../scripts/main.js" defer></script>
     <script type="module" src="../scripts/signup.js"></script>
   </head>
-  
 <body>
   <!-- 헤더는 components.js에 의해 여기에 삽입됩니다 -->
 
@@ -79,7 +79,7 @@
           Google
         </button>
 
-        <button class="btn btn-kakao btn-block">
+        <button id="kakao-login-btn"  class="btn btn-kakao btn-block">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18">
             <path fill="#3A1D1D" d="M12 3C7.03 3 3 6.14 3 10c0 2.44 1.56 4.61 3.94 5.8-.18.69-.71 2.51-.82 2.9-.12.47.18.46.38.33.16-.09 2.46-1.67 3.46-2.35.33.05.67.07 1.04.07 4.97 0 9-3.14 9-7S16.97 3 12 3z"/>
           </svg>

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -152,3 +152,24 @@ export async function deleteAccount() {
         throw new Error(error.response?.data?.detail || "회원 탈퇴 실패. 다시 시도하세요.");
     }
 }
+
+// 카카오 로그인 요청 (POST /accounts/kakao-login/)
+export async function kakaoLogin(kakaoAccessToken) {
+    try {
+        const response = await axiosInstance.post("/accounts/kakao-login/", {
+            access_token: kakaoAccessToken,
+        });
+
+        const { access, refresh, user } = response.data;
+
+        // JWT 토큰 저장
+        localStorage.setItem("access_token", access);
+        localStorage.setItem("refresh_token", refresh);
+        localStorage.setItem("user_email", user.email);
+
+        return user; // 로그인한 사용자 정보 반환
+    } catch (error) {
+        console.error("카카오 로그인 실패:", error.response?.data || error.message);
+        throw new Error(error.response?.data?.detail || "카카오 로그인 실패. 다시 시도하세요.");
+    }
+}

--- a/scripts/profile_edit.js
+++ b/scripts/profile_edit.js
@@ -242,15 +242,18 @@ function getFormData() {
     const regionValue = document.getElementById("region").value;
     const subregionValue = document.getElementById("subregion").value;
 
-    // ✅ 시/도를 선택했지만 시/군/구를 선택하지 않은 경우 저장 불가
+    // 시/도를 선택했지만 시/군/구를 선택하지 않은 경우 저장 불가
     if (regionValue && !subregionValue) {
         alert("시/군/구를 선택하세요.");
         return null; // 유효성 검사 실패 시 null 반환 → 저장 중단
     }
 
+    const birthDateRaw = document.getElementById("birth_date").value.trim();
+    const birth_date = birthDateRaw === "" ? null : birthDateRaw;
+
     return {
         name: document.getElementById("name").value,
-        birth_date: document.getElementById("birth_date").value,
+        birth_date: birth_date,
         location: document.getElementById("subregion").value || null,
         current_status: document.getElementById("current_status").value || null,
         education_level: document.getElementById("education_level").value || null,

--- a/scripts/signup.js
+++ b/scripts/signup.js
@@ -1,49 +1,76 @@
-import { signup } from "./api.js"; // API 요청 함수 불러오기
+import { signup, kakaoLogin } from "./api.js";
+
+// 카카오 SDK 초기화 (config.js에서 KAKAO_JS_KEY를 전역으로 제공 중)
+Kakao.init(window.appConfig.KAKAO_JS_KEY);
 
 document.addEventListener("DOMContentLoaded", function () {
     const signupForm = document.getElementById("signup-form");
     const resultMessage = document.getElementById("message-container");
+    const kakaoLoginBtn = document.getElementById("kakao-login-btn");
 
+    // 1. 회원가입 처리
     signupForm.addEventListener("submit", async function (event) {
         event.preventDefault(); // 기본 폼 제출 방지
 
-        // 입력된 값 가져오기
-        const email = document.getElementById("email").value;
+        const email = document.getElementById("email").value.trim();
         const password = document.getElementById("password").value;
         const password2 = document.getElementById("password2").value;
         const termsAgree = document.getElementById("terms_agree").checked;
         const marketingAgree = document.getElementById("marketing_agree").checked;
 
-        // 비밀번호 확인 검사
+        // 비밀번호 확인
         if (password !== password2) {
             showMessage("비밀번호가 일치하지 않습니다.", "error");
             return;
         }
 
-        const userData = { email, password, terms_agree: termsAgree, marketing_agree: marketingAgree };
+        const userData = {
+            email,
+            password,
+            terms_agree: termsAgree,
+            marketing_agree: marketingAgree,
+        };
 
         try {
             // 회원가입 API 호출
             await signup(userData);
-
             showMessage("회원가입 성공! 로그인 페이지로 이동합니다.", "success");
 
-            // 2초 후 로그인 페이지로 이동
+            // 2초 후 로그인 페이지 이동
             setTimeout(() => {
                 window.location.href = "login.html";
             }, 2000);
-
         } catch (error) {
             console.error("회원가입 실패:", error);
             showMessage(error.message || "회원가입 중 오류가 발생했습니다.", "error");
         }
     });
 
-    /**
-     * 메시지 표시 함수
-     * @param {string} message - 표시할 메시지
-     * @param {string} type - "success" | "error"
-     */
+    // 2. 카카오 로그인 처리
+    kakaoLoginBtn.addEventListener("click", () => {
+        Kakao.Auth.login({
+            throughTalk: false,
+            persistAccessToken: false,
+            success: async function (authObj) {
+                const kakaoAccessToken = authObj.access_token;
+
+                try {
+                    const user = await kakaoLogin(kakaoAccessToken);
+                    alert(`${user.name || "사용자"}님 환영합니다!`);
+                    window.location.href = "/index.html";
+                } catch (error) {
+                    console.error("카카오 로그인 실패:", error);
+                    showMessage(error.message || "카카오 로그인 실패", "error");
+                }
+            },
+            fail: function (err) {
+                console.error("카카오 SDK 인증 실패:", err);
+                showMessage("카카오 로그인 인증 중 오류가 발생했습니다.", "error");
+            },
+        });
+    });
+
+    // 3. 메시지 출력 함수
     function showMessage(message, type) {
         resultMessage.innerHTML = `<p class="message ${type}">${message}</p>`;
         resultMessage.style.display = "block";


### PR DESCRIPTION
## 관련 이슈
- 없음

## 작업 내용
<!-- 작업한 내용을 자세히 설명해주세요 -->
- 카카오 로그인 기능 구현 (SDK 연동 및 사용자 인증 처리)
- `config.js`에 Kakao JavaScript 키 등록 및 SDK 초기화 코드 추가
- `login.js`, `signup.js`에서 카카오 로그인 버튼 클릭 시 `Kakao.Auth.login()` 호출
- 로그인 성공 시 백엔드에 토큰 전달하여 JWT 발급 및 로컬 스토리지 저장
- 로그인 후 유저 이름 기반 환영 알림 및 메인 페이지 리디렉션
- `signup.js`에 `window.Kakao` 초기화 문제 해결
- 생년월일 처리 관련 로직 리팩터링 및 주석 정리

## 테스트 체크리스트
<!-- [ ]안에 x를 입력하면 체크됩니다 -->
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->
<img width="1104" alt="image" src="https://github.com/user-attachments/assets/44e446f3-d43a-4e03-a5e7-c64eb7f2169a" />

## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->
- Google 로그인 버튼은 현재 UI에만 존재하며 기능은 미구현 상태입니다.
- Kakao SDK 초기화 순서 주의 필요: `kakao.js` → `config.js` → 나머지 스크립트