### PR TITLE
Feat/social login google

### DIFF
--- a/pages/login.html
+++ b/pages/login.html
@@ -15,6 +15,7 @@
   
     <!-- JavaScript 파일들 -->
     <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script src="https://accounts.google.com/gsi/client"></script>
     <script type="module" src="../config/config.js"></script>
     <script type="module" src="../scripts/api.js"></script>
     <script type="module" src="../scripts/components.js"></script>
@@ -51,15 +52,7 @@
           <span>Or sign in with</span>
         </div>
         
-        <button class="btn btn-google btn-block">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18">
-            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
-            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
-            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
-            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
-          </svg>
-          Google
-        </button>
+        <div id="google-login-btn" class="google-btn-container"></div>
 
         <button id="kakao-login-btn" class="btn btn-kakao btn-block">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18">

--- a/pages/signup.html
+++ b/pages/signup.html
@@ -15,6 +15,7 @@
   
     <!-- JavaScript 파일들 -->
     <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script src="https://accounts.google.com/gsi/client"></script>
     <script type="module" src="../config/config.js"></script>
     <script type="module" src="../scripts/api.js"></script>
     <script type="module" src="../scripts/components.js"></script>
@@ -69,15 +70,7 @@
           <span>Or sign in with</span>
         </div>
         
-        <button class="btn btn-google btn-block">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18">
-            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
-            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
-            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
-            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
-          </svg>
-          Google
-        </button>
+        <div id="google-login-btn" class="google-btn-container"></div>
 
         <button id="kakao-login-btn"  class="btn btn-kakao btn-block">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18">

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -173,3 +173,24 @@ export async function kakaoLogin(kakaoAccessToken) {
         throw new Error(error.response?.data?.detail || "카카오 로그인 실패. 다시 시도하세요.");
     }
 }
+
+// 구글 로그인 요청 (POST /accounts/google-login/)
+export async function googleLogin(googleIdToken) {
+    try {
+        const response = await axiosInstance.post("/accounts/google-login/", {
+            id_token: googleIdToken,
+        });
+
+        const { access, refresh, user } = response.data;
+
+        // JWT 토큰 저장
+        localStorage.setItem("access_token", access);
+        localStorage.setItem("refresh_token", refresh);
+        localStorage.setItem("user_email", user.email);
+
+        return user; // 로그인한 사용자 정보 반환
+    } catch (error) {
+        console.error("구글 로그인 실패:", error.response?.data || error.message);
+        throw new Error(error.response?.data?.detail || "구글 로그인 실패. 다시 시도하세요.");
+    }
+}

--- a/scripts/login.js
+++ b/scripts/login.js
@@ -1,4 +1,4 @@
-import { login, kakaoLogin } from "./api.js"; // 일반 로그인 + 카카오 로그인
+import { login, kakaoLogin, googleLogin } from "./api.js"; // 일반 로그인 + 카카오 로그인
 
 // 카카오 SDK 초기화 (config.js에서 KAKAO_JS_KEY를 전역으로 제공 중)
 Kakao.init(window.appConfig.KAKAO_JS_KEY);
@@ -7,6 +7,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const loginForm = document.getElementById("login-form");
     const resultMessage = document.getElementById("message-container");
     const kakaoLoginBtn = document.getElementById("kakao-login-btn");
+    const googleLoginDiv = document.getElementById("google-login-btn");
 
     // 1. 이메일/비밀번호 로그인
     loginForm.addEventListener("submit", async function (event) {
@@ -61,6 +62,38 @@ document.addEventListener("DOMContentLoaded", function () {
             },
         });
     });
+
+    // 3. 구글 로그인 초기화 및 콜백 처리
+    window.onload = function () {
+        google.accounts.id.initialize({
+            client_id: window.appConfig.GOOGLE_CLIENT_ID,
+            callback: async function (response) {
+                const idToken = response.credential;
+
+                try {
+                    const user = await googleLogin(idToken);
+                    alert(`${user.name || "사용자"}님 환영합니다!`);
+                    window.location.href = "/index.html";
+                } catch (error) {
+                    console.error("구글 로그인 실패:", error);
+                    showMessage(error.message || "구글 로그인 실패", "error");
+                }
+            },
+        });
+
+        // 구글 로그인 버튼 렌더링
+        if (googleLoginDiv) {
+            google.accounts.id.renderButton(googleLoginDiv, {
+                type: "standard",
+                theme: "outline",
+                size: "large",
+                text: "signin_with",
+                shape: "rectangular",
+                logo_alignment: "left",
+                width: googleLoginDiv.offsetWidth,
+            });
+        }
+    };
 
     // 공통 메시지 출력 함수
     function showMessage(message, type) {

--- a/scripts/signup.js
+++ b/scripts/signup.js
@@ -1,4 +1,4 @@
-import { signup, kakaoLogin } from "./api.js";
+import { signup, kakaoLogin, googleLogin } from "./api.js";
 
 // 카카오 SDK 초기화 (config.js에서 KAKAO_JS_KEY를 전역으로 제공 중)
 Kakao.init(window.appConfig.KAKAO_JS_KEY);
@@ -7,6 +7,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const signupForm = document.getElementById("signup-form");
     const resultMessage = document.getElementById("message-container");
     const kakaoLoginBtn = document.getElementById("kakao-login-btn");
+    const googleLoginDiv = document.getElementById("google-login-btn");
 
     // 1. 회원가입 처리
     signupForm.addEventListener("submit", async function (event) {
@@ -69,6 +70,38 @@ document.addEventListener("DOMContentLoaded", function () {
             },
         });
     });
+
+    // 3. 구글 로그인 초기화 및 콜백 처리
+    window.onload = function () {
+        google.accounts.id.initialize({
+            client_id: window.appConfig.GOOGLE_CLIENT_ID,
+            callback: async function (response) {
+                const idToken = response.credential;
+
+                try {
+                    const user = await googleLogin(idToken);
+                    alert(`${user.name || "사용자"}님 환영합니다!`);
+                    window.location.href = "/index.html";
+                } catch (error) {
+                    console.error("구글 로그인 실패:", error);
+                    showMessage(error.message || "구글 로그인 실패", "error");
+                }
+            },
+        });
+
+        // 구글 로그인 버튼 렌더링
+        if (googleLoginDiv) {
+            google.accounts.id.renderButton(googleLoginDiv, {
+                type: "standard",
+                theme: "outline",
+                size: "large",
+                text: "signin_with",
+                shape: "rectangular",
+                logo_alignment: "left",
+                width: googleLoginDiv.offsetWidth,
+            });
+        }
+    };
 
     // 3. 메시지 출력 함수
     function showMessage(message, type) {


### PR DESCRIPTION
## 관련 이슈
- 없음

## 작업 내용
<!-- 작업한 내용을 자세히 설명해주세요 -->
- `<div id="google-login-btn">` 을 활용하여 로그인 UI 구성
- Google SDK (`gsi.client`) 로드 및 `initialize()` 설정
- 로그인 성공 시 ID Token을 백엔드로 전송하여 JWT 발급받도록 연결
- 버튼 스타일 조정 (카카오 로그인 버튼과 동일한 높이/너비로 통일)

## 테스트 체크리스트
<!-- [ ]안에 x를 입력하면 체크됩니다 -->
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/7bb5a338-58d9-4a17-971c-caf060bcefae" />
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/06b3e1c1-b30d-43b9-86a2-1ed2f4e9c811" />

## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->
- 구글 로그인은 Google One Tap 방식 로그인으로 구현되었습니다.