### PR TITLE
🐛 Fix: 만료된 access 토큰 자동 갱신 로직 추가

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -194,3 +194,43 @@ export async function googleLogin(googleIdToken) {
     throw new Error(error.response?.data?.detail || '구글 로그인 실패. 다시 시도하세요.');
   }
 }
+
+// 새 access 토큰 발급
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    // access 토큰이 만료되어 401 에러가 발생한 경우
+    if (
+      error.response?.status === 401 &&
+      !originalRequest._retry && // 무한루프 방지용 플래그
+      localStorage.getItem("refresh_token")
+    ) {
+      originalRequest._retry = true;
+
+      try {
+        const refreshResponse = await axios.post("/api/v1/accounts/token/refresh/", {
+          refresh: localStorage.getItem("refresh_token"),
+        });
+
+        const newAccessToken = refreshResponse.data.access;
+
+        // 새 access 토큰 저장
+        localStorage.setItem("access_token", newAccessToken);
+
+        // 실패했던 요청에 새 토큰 설정 후 재요청
+        originalRequest.headers["Authorization"] = `Bearer ${newAccessToken}`;
+        return axiosInstance(originalRequest);
+      } catch (refreshError) {
+        // refresh 토큰도 만료되었을 때 → 로그아웃 처리
+        localStorage.removeItem("access_token");
+        localStorage.removeItem("refresh_token");
+        window.location.href = "/login.html"; // 로그인 페이지로 리디렉션
+        return Promise.reject(refreshError);
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -205,28 +205,28 @@ axiosInstance.interceptors.response.use(
     if (
       error.response?.status === 401 &&
       !originalRequest._retry && // 무한루프 방지용 플래그
-      localStorage.getItem("refresh_token")
+      localStorage.getItem('refresh_token')
     ) {
       originalRequest._retry = true;
 
       try {
-        const refreshResponse = await axios.post("/api/v1/accounts/token/refresh/", {
-          refresh: localStorage.getItem("refresh_token"),
+        const refreshResponse = await axios.post('/api/v1/accounts/token/refresh/', {
+          refresh: localStorage.getItem('refresh_token'),
         });
 
         const newAccessToken = refreshResponse.data.access;
 
         // 새 access 토큰 저장
-        localStorage.setItem("access_token", newAccessToken);
+        localStorage.setItem('access_token', newAccessToken);
 
         // 실패했던 요청에 새 토큰 설정 후 재요청
-        originalRequest.headers["Authorization"] = `Bearer ${newAccessToken}`;
+        originalRequest.headers['Authorization'] = `Bearer ${newAccessToken}`;
         return axiosInstance(originalRequest);
       } catch (refreshError) {
         // refresh 토큰도 만료되었을 때 → 로그아웃 처리
-        localStorage.removeItem("access_token");
-        localStorage.removeItem("refresh_token");
-        window.location.href = "/login.html"; // 로그인 페이지로 리디렉션
+        localStorage.removeItem('access_token');
+        localStorage.removeItem('refresh_token');
+        window.location.href = '/login.html'; // 로그인 페이지로 리디렉션
         return Promise.reject(refreshError);
       }
     }


### PR DESCRIPTION
## 관련 이슈
- 없음

## 작업 내용
<!-- 작업한 내용을 자세히 설명해주세요 -->
- access token이 만료되었을 때 자동으로 refresh token을 사용해 access token을 재발급받는 로직 추가
- axios 응답 인터셉터를 활용해 401 응답 시 토큰 갱신 후 실패한 요청 자동 재시도
- refresh 토큰도 만료된 경우, localStorage에서 토큰 삭제 후 로그인 페이지로 리다이렉트 처리

## 테스트 체크리스트
<!-- [ ]안에 x를 입력하면 체크됩니다 -->
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->
(해당 없음)

## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->
- `/api/v1/accounts/token/refresh/` 엔드포인트는 백엔드에서 이미 구현되어 있어야 정상 동작합니다.
- 모든 API 요청은 반드시 `axiosInstance`를 사용해야 자동 리프레시가 작동합니다.
