### PR TITLE
🐛 Fix: API 경로 수정 및 로그인 페이지 리디렉션 경로 변경

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -210,7 +210,7 @@ axiosInstance.interceptors.response.use(
       originalRequest._retry = true;
 
       try {
-        const refreshResponse = await axios.post('/api/v1/accounts/token/refresh/', {
+        const refreshResponse = await axiosInstance.post('/accounts/token/refresh/', {
           refresh: localStorage.getItem('refresh_token'),
         });
 
@@ -226,7 +226,7 @@ axiosInstance.interceptors.response.use(
         // refresh 토큰도 만료되었을 때 → 로그아웃 처리
         localStorage.removeItem('access_token');
         localStorage.removeItem('refresh_token');
-        window.location.href = '/login.html'; // 로그인 페이지로 리디렉션
+        window.location.href = '/pages/login.html'; // 로그인 페이지로 리디렉션
         return Promise.reject(refreshError);
       }
     }


### PR DESCRIPTION
## 관련 이슈
- 없음

## 작업 내용
<!-- 작업한 내용을 자세히 설명해주세요 -->
- `axios.post()`로 refresh 요청을 보내던 부분을 `axiosInstance.post()`로 수정하여 baseURL이 적용되도록 변경
- 이로 인해 access token이 만료되었을 때 자동으로 refresh가 정상 작동하도록 수정
- refresh 실패 시 자동 로그아웃 및 리디렉션 처리 로직은 그대로 유지

## 테스트 체크리스트
<!-- [ ]안에 x를 입력하면 체크됩니다 -->
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->
(해당 없음)

## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->
- DevTools > Network 탭에서 `/accounts/token/refresh/` 요청이 `baseURL`로 정확히 날아가는지 확인 필수
- 토큰 만료 시간은 Django `settings.py`에서 실험용으로 조정 가능
