### PR TITLE
Refactor/chatbot style

### DIFF
--- a/pages/chatbot.html
+++ b/pages/chatbot.html
@@ -56,6 +56,8 @@
         <div class="chat-container">
             <div class="chat-header">
                 <h2>AInfo 챗봇</h2>
+                <!-- 크루 모드 버튼 -->
+                <button id="crew-report-btn" title="입력한 질문을 기반으로 보고서를 생성해줍니다.">📄 보고서</button>
             </div>
             
             <div id="chat-messages">

--- a/scripts/chat-app.js
+++ b/scripts/chat-app.js
@@ -31,6 +31,21 @@ class ChatApp {
       this.userInput.style.height = 'auto';
       this.userInput.style.height = Math.min(this.userInput.scrollHeight, 120) + 'px';
     });
+
+    // 보고서 버튼 이벤트 리스너 추가
+    this.inputMode = 'default';
+
+    const crewBtn = document.getElementById('crew-report-btn');
+    crewBtn.addEventListener('click', () => {
+      const isActive = crewBtn.classList.toggle('active');
+      this.inputMode = isActive ? 'crew_report' : 'default';
+
+      if (isActive) {
+        this.renderer.addSystemMessage('📝 보고서 생성 모드입니다.');
+      } else {
+        this.renderer.addSystemMessage('✏️ 일반 대화 모드로 돌아왔습니다.');
+      }
+    });
   }
 
   async sendMessage() {

--- a/styles/chatbot.css
+++ b/styles/chatbot.css
@@ -202,9 +202,12 @@
 
 /* 채팅 헤더 */
 .chat-header {
-    padding: 15px 20px;
+    padding: 10px 20px;
     background-color: #f8f9fa;
     border-bottom: 1px solid #eaeaea;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 
 .chat-header h2 {
@@ -214,10 +217,31 @@
     color: #333;
 }
 
+#crew-report-btn {
+    background-color: #53b2ac88;
+    border: none;
+    border-radius: 8px;
+    padding: 8px 14px;
+    cursor: pointer;
+    font-size: 16px;
+    transition: background-color 0.2s ease;
+}
+
+#crew-report-btn:hover {
+    background-color: #33736f;
+    color: white;
+}
+
+#crew-report-btn.active {
+    background-color: #2e7d78; /* 좀 더 진한 색으로 강조 */
+    color: white;
+    box-shadow: 0 0 0 2px rgba(83, 178, 172, 0.3);
+}
+
 /* 채팅 메시지 영역 */
 #chat-messages {
     flex: 1;
-    padding: 20px;
+    padding: 20px; 
     overflow-y: auto;
     display: flex;
     flex-direction: column;
@@ -354,6 +378,18 @@
 
 .markdown-content p {
     margin-bottom: 10px;
+}
+
+.markdown-content a {
+    color: #007bff; /* 링크 색상 */
+    text-decoration: underline; /* 밑줄 */
+    word-break: break-word; /* 긴 링크 줄바꿈 */
+    transition: color 0.2s ease;
+}
+
+.markdown-content a:hover {
+    color: #0056b3; /* 호버 시 진한 파란색 */
+    text-decoration: underline;
 }
 
 .markdown-content ul, .markdown-content ol {

--- a/styles/chatbot.css
+++ b/styles/chatbot.css
@@ -235,7 +235,7 @@
 #crew-report-btn.active {
     background-color: #2e7d78; /* 좀 더 진한 색으로 강조 */
     color: white;
-    box-shadow: 0 0 0 2px rgba(83, 178, 172, 0.3);
+    box-shadow: 0 0 0 2px rgb(83 178 172 / 30%);
 }
 
 /* 채팅 메시지 영역 */


### PR DESCRIPTION
## 관련 이슈
- (없음)

## 작업 내용
<!-- 작업한 내용을 자세히 설명해주세요 -->
- 챗봇 입력창에 "📄 보고서 " 버튼 추가
  - 버튼 클릭 시 활성화 상태 유지 (`.active` 클래스 토글)
- 마크다운 링크 스타일 적용
  - `<a>` 태그에 파란색 강조, 밑줄, 호버 효과 추가
  - 긴 링크는 자동 줄바꿈되도록 `word-break` 설정

## 테스트 체크리스트
<!-- [ ]안에 x를 입력하면 체크됩니다 -->
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->
<img width="1433" alt="image" src="https://github.com/user-attachments/assets/b3532186-61e5-4a97-ba2e-5bb638d509fa" />

## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->
- 보고서 생성 모드는 이후 CrewAI 연동 필요
- 보고서 버튼 활성화하고 전송 후 자동으로 활성화 해제하거나 유지할 수 있도록 구조 설계 필요
