### PR TITLE
Feature/chat UI flow enhance

### DIFF
--- a/scripts/chat-app.js
+++ b/scripts/chat-app.js
@@ -67,9 +67,9 @@ class ChatApp {
 
     this.renderer.addUserMessage(message);
     if (this.inputMode === 'crew_report') {
-      this.renderer.addLoadingMessage("📄 보고서 생성에는 1분 정도 소요됩니다...");
+      this.renderer.addLoadingMessage('📄 보고서 생성에는 1분 정도 소요됩니다...');
     } else {
-      this.renderer.addLoadingMessage("답변을 생성 중입니다...");
+      this.renderer.addLoadingMessage('답변을 생성 중입니다...');
     }
 
     if (this.inputMode === 'crew_report') {

--- a/scripts/chat-app.js
+++ b/scripts/chat-app.js
@@ -49,18 +49,35 @@ class ChatApp {
   }
 
   async sendMessage() {
+    if (this.isBotResponding) return;
     const message = this.userInput.value;
     if (!message.trim()) return;
-
-    this.renderer.addUserMessage(message);
-    this.renderer.addLoadingMessage();
+    
+    this.isBotResponding = true;
+    this.userInput.disabled = true;
+    this.sendButton.disabled = true;
+    
     this.userInput.value = '';
     this.userInput.style.height = 'auto';
     // this.renderer.resetCurrentMessage();
-
+    
     // 메시지 상태만 초기화하고 스피너는 유지
     this.renderer.currentBotMessage = null;
     this.renderer.currentMarkdownText = '';
+
+    this.renderer.addUserMessage(message);
+    if (this.inputMode === 'crew_report') {
+      this.renderer.addLoadingMessage("📄 보고서 생성에는 1분 정도 소요됩니다...");
+    } else {
+      this.renderer.addLoadingMessage("답변을 생성 중입니다...");
+    }
+
+    if (this.inputMode === 'crew_report') {
+      const crewBtn = document.getElementById('crew-report-btn');
+      crewBtn.classList.remove('active');
+      this.inputMode = 'default';
+      this.renderer.addSystemMessage('✏️ 일반 대화 모드로 돌아왔습니다.');
+    }
     // 아직 연결되지 않았을 때
     if (!this.websocketService) {
       this.firstUserMessage = message;
@@ -97,7 +114,7 @@ class ChatApp {
     this.firstUserMessage = this.pendingMessage;
 
     
-    // ✅ "안녕하세요!" 메시지를 항상 맨 위에 먼저 추가
+    // "안녕하세요!" 메시지를 항상 맨 위에 먼저 추가
     //this.chatMessages.innerHTML = '';
     //this.renderer.addBotMessageInitial('안녕하세요! 무엇을 도와드릴까요?');
     
@@ -106,9 +123,18 @@ class ChatApp {
         // 스트리밍 시작 시 로딩 메시지 제거
         if (isStreaming && !this.renderer.currentBotMessage) {
           this.renderer.removeLoadingMessage();
+          this.isBotResponding = true;
+          this.userInput.disabled = true;
+          this.sendButton.disabled = true;
         }
         
         this.renderer.addBotMessage(message, isStreaming);
+
+        if (!isStreaming) {
+          this.isBotResponding = false;
+          this.userInput.disabled = false;
+          this.sendButton.disabled = false;
+        }
 
         if (!isStreaming && !this.isFirstResponseHandled) {
           this.isFirstResponseHandled = true;

--- a/scripts/chat-renderer.js
+++ b/scripts/chat-renderer.js
@@ -1,5 +1,13 @@
 // chat-renderer.js : 채팅 메시지 렌더링 담당
 
+marked.use({
+  renderer: {
+    link(href, title, text) {
+      return `<a href="${href}" target="_blank" rel="noopener noreferrer"${title ? ` title="${title}"` : ''}>${text}</a>`;
+    }
+  }
+});
+
 class ChatRenderer {
   constructor(chatMessagesElement) {
     this.chatMessages = chatMessagesElement;
@@ -89,7 +97,7 @@ class ChatRenderer {
     this.scrollToBottom();
   }
 
-  addLoadingMessage() {
+  addLoadingMessage(message = '답변을 생성 중입니다...') {
     this.removeLoadingMessage(); // 중복 방지
 
     const loadingContainer = document.createElement('div');
@@ -103,7 +111,7 @@ class ChatRenderer {
 
     const messageElement = document.createElement('div');
     messageElement.classList.add('message', 'bot-message');
-    messageElement.innerHTML = '<span>답변을 생성 중입니다...</span>';
+    messageElement.innerHTML = `<span>${message}</span>`;
 
     loadingContainer.appendChild(profileImg);
     loadingContainer.appendChild(messageElement);

--- a/styles/chatbot.css
+++ b/styles/chatbot.css
@@ -412,6 +412,26 @@
     margin-bottom: 10px;
 }
 
+.markdown-content table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 16px;
+    font-size: 14px;
+}
+
+.markdown-content th,
+.markdown-content td {
+    border: 1px solid #d9d9d9;
+    padding: 10px;
+    text-align: left;
+}
+
+.markdown-content th {
+    background-color: #4fa09bd3;
+    color: #333;
+    font-weight: 600;
+}
+
 /* 로딩 애니메이션 */
 .message-wrapper.loading {
     align-items: center;


### PR DESCRIPTION
## 관련 이슈
- 없음

## 작업 내용
<!-- 작업한 내용을 자세히 설명해주세요 -->
- 챗봇 응답 중(`답변 생성 중입니다...`) 상태에서는 사용자 입력 및 전송 버튼 비활성화 처리
- 보고서 모드(`📄 보고서`) 활성화 상태에서 질문 전송 시:
  - 안내 메시지를 "보고서 생성에는 1분 정도 소요됩니다..."로 변경
  - 보고서 모드 자동 종료 및 일반 모드로 전환
  - 입력창 초기화 처리
- 마크다운 링크 클릭 시 새 탭에서 열리도록 설정 (`target="_blank"` 적용)

## 테스트 체크리스트
<!-- [ ]안에 x를 입력하면 체크됩니다 -->
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->
<img width="1461" alt="image" src="https://github.com/user-attachments/assets/f42494e2-12d8-483d-8871-c5a8fd90cec0" />

## 참고 사항
<!-- 레포주인이 참고해야할 내용을 적어주세요 -->
- 추가적으로 "답변 생성 중단 기능"은 백엔드 협업이 필요하므로 미포함
- 추후 응답 취소 기능이 필요할 경우 별도 이슈로 관리 권장
